### PR TITLE
Disable nginx access logs

### DIFF
--- a/f1newrelic/files/file.yml.jinja
+++ b/f1newrelic/files/file.yml.jinja
@@ -5,7 +5,7 @@
 ###############################################################################
 {% if 'web-server' in grains.get('roles',[]) %}
 logs:
-{% for env in grains.env -%}
+{# {% for env in grains.env -%}
 {% for site_name, site in pillar.vhosts.sites.items() -%}
 {% for instance_name, instance in site.instances.items() -%}
 {% if env == instance_name %}
@@ -14,7 +14,7 @@ logs:
 {% endif %}
 {%- endfor %}
 {%- endfor %}
-{%- endfor %}
+{%- endfor %} #}
   - name: nginx error
     file: /var/log/nginx/error.log
 


### PR DESCRIPTION
We're going to disable shipping nginx site access logs - in discussions with Aaron Z, the logs we want to focus on to ship to New Relic are the error logs for nginx and php-fpm, as well as the Drupal/Wordpress logs.  

Another PR will be open to ship the CMS logs once we have the details about the CMS log destination figured out.