### PR TITLE
Disable NFSSampler for the infrastructure agent

### DIFF
--- a/f1newrelic/files/newrelic-infra.yml.jinja
+++ b/f1newrelic/files/newrelic-infra.yml.jinja
@@ -11,3 +11,6 @@ custom_attributes:
   {% endif %}
 {%- endfor %}
 {% endif %}
+
+# Disable sampling NFS
+metrics_nfs_sample_rate: -1


### PR DESCRIPTION
This must have happened in an infrastructure agent update, but without disabling nfs metrics, log files are being inundated with the following error message:
```Jun 10 18:42:15 ip-10-250-2-162 newrelic-infra-service: time="2022-06-10T18:42:15Z" level=warning msg="Unable to retrieve NFS stats." component=NFSSampler error="no supported NFS mounts found"
Jun 10 18:42:35 ip-10-250-2-162 newrelic-infra-service: time="2022-06-10T18:42:35Z" level=warning msg="Unable to retrieve NFS stats." component=NFSSampler error="no supported NFS mounts found"
Jun 10 18:42:55 ip-10-250-2-162 newrelic-infra-service: time="2022-06-10T18:42:55Z" level=warning msg="Unable to retrieve NFS stats." component=NFSSampler error="no supported NFS mounts found"
```

This PR disables the attempted collection of these stats