### PR TITLE
This PR fixes some whitespace formatting issues with the rendered new…

### DIFF
--- a/f1newrelic/files/newrelic-infra.yml.jinja
+++ b/f1newrelic/files/newrelic-infra.yml.jinja
@@ -1,12 +1,8 @@
 license_key: {{ newrelic_license }}
 display_name: {{ project }}.byf1.dev ({{ infra_agent_name }})
-{% if grains.roles is defined %}
+{% if 'utility' in roles %}
 custom_attributes:
-{%- for role in grains.roles -%}
-  {%- if role == 'utility' %}
-  role: {{ role }}
-  {%- endif %}
-{%- endfor %}
+  role: utility
 {%- endif %}
 
 metrics_nfs_sample_rate: -1

--- a/f1newrelic/files/newrelic-infra.yml.jinja
+++ b/f1newrelic/files/newrelic-infra.yml.jinja
@@ -1,16 +1,12 @@
-{% from "f1newrelic/map.jinja" import infra_agent_name, project, newrelic_license with context %}
-
 license_key: {{ newrelic_license }}
 display_name: {{ project }}.byf1.dev ({{ infra_agent_name }})
-
 {% if grains.roles is defined %}
 custom_attributes:
-{%- for role in grains.roles %}
-  {% if role == 'utility' %}
+{%- for role in grains.roles -%}
+  {%- if role == 'utility' %}
   role: {{ role }}
-  {% endif %}
+  {%- endif %}
 {%- endfor %}
-{% endif %}
+{%- endif %}
 
-# Disable sampling NFS
 metrics_nfs_sample_rate: -1

--- a/f1newrelic/init.sls
+++ b/f1newrelic/init.sls
@@ -26,6 +26,7 @@ newrelic-infra:
         infra_agent_name: {{ infra_agent_name }}
         newrelic_license: {{ newrelic_license }}
         project:  {{ project }}
+        roles: {{ salt['grains.get']('roles', '') }}
 
 /etc/newrelic-infra/logging.d/logging.yml:
   file.managed:

--- a/f1newrelic/init.sls
+++ b/f1newrelic/init.sls
@@ -22,6 +22,10 @@ newrelic-infra:
     - name: /etc/newrelic-infra.yml
     - user: root
     - mode: 0640
+    - context:
+      infra_agent_name: {{ infra_agent_name }}
+      newrelic_license: {{ newrelic_license }}
+      project:  {{ project }}
 
 /etc/newrelic-infra/logging.d/logging.yml:
   file.managed:

--- a/f1newrelic/init.sls
+++ b/f1newrelic/init.sls
@@ -23,9 +23,9 @@ newrelic-infra:
     - user: root
     - mode: 0640
     - context:
-      infra_agent_name: {{ infra_agent_name }}
-      newrelic_license: {{ newrelic_license }}
-      project:  {{ project }}
+        infra_agent_name: {{ infra_agent_name }}
+        newrelic_license: {{ newrelic_license }}
+        project:  {{ project }}
 
 /etc/newrelic-infra/logging.d/logging.yml:
   file.managed:


### PR DESCRIPTION
…relic-infra.yml file.

The current/old file renders like this:
```


license_key: <redacted>
display_name: <anyclient usa>


custom_attributes:

  role: utility




# Disable sampling NFS
metrics_nfs_sample_rate: -1
```

Setting context for the template file instead of using a from block, and using whitespace control characters, it now renders like this:

```
license_key: <redacted>
display_name: <anyclient usa>

custom_attributes:
  role: utility

metrics_nfs_sample_rate: -1
```

Note, I removed the metrics_nfs_sample_rate comment on purpose.  